### PR TITLE
[WIP] Utils documentation - enabling hyperlinks

### DIFF
--- a/doc/developers/utilities.rst
+++ b/doc/developers/utilities.rst
@@ -68,6 +68,15 @@ For example::
     >>> random_state.rand(4)
     array([ 0.5488135 ,  0.71518937,  0.60276338,  0.54488318])
 
+When developing your own scikit-learn compatible estimator, the following
+helpers are available.
+
+- :func:`validation.check_is_fitted`: check that the estimator has been fitted
+  before calling ``transform``, ``predict``, or similar methods. This helper
+  allows to raise a standardized error message across estimator.
+
+- :func:`validation.has_fit_parameter`: check that a given parameter is
+  supported in the ``fit`` method of a given estimator.
 
 Efficient Linear Algebra & Array Operations
 ===========================================

--- a/doc/modules/classes.rst
+++ b/doc/modules/classes.rst
@@ -1353,8 +1353,13 @@ Low-level methods
    :toctree: generated/
    :template: function.rst
 
-
+   utils.assert_all_finite
+   utils.as_float_array
+   utils.check_X_y
+   utils.check_array
+   utils.check_consistent_length
    utils.check_random_state
+   utils.indexable
    utils.class_weight.compute_class_weight
    utils.class_weight.compute_sample_weight
    utils.estimator_checks.check_estimator
@@ -1368,13 +1373,10 @@ Low-level methods
    utils.sparsefuncs.inplace_row_scale
    utils.sparsefuncs.inplace_swap_row
    utils.sparsefuncs.inplace_swap_column
-   utils.validation.check_X_y
-   utils.validation.check_array
-   utils.validation.check_consistent_length
    utils.validation.check_is_fitted
-   utils.validation.check_random_state
    utils.validation.check_symmetric
    utils.validation.column_or_1d
+   utils.validation.has_fit_parameter
 
 Recently deprecated
 ===================

--- a/sklearn/utils/extmath.py
+++ b/sklearn/utils/extmath.py
@@ -185,13 +185,13 @@ def safe_sparse_dot(a, b, dense_output=False):
     a : array or sparse matrix
     b : array or sparse matrix
     dense_output : boolean, default False
-        When False, either a or b being sparse will yield sparse output.
-        When True, output will always be an array.
+        When False, either ``a`` or ``b`` being sparse will yield sparse
+        output. When True, output will always be an array.
 
     Returns
     -------
     dot_product : array or sparse matrix
-        sparse if a or b is sparse and dense_output=False.
+        sparse if ``a`` or ``b`` is sparse and ``dense_output``=False.
     """
     if issparse(a) or issparse(b):
         ret = a * b

--- a/sklearn/utils/multiclass.py
+++ b/sklearn/utils/multiclass.py
@@ -1,4 +1,3 @@
-
 # Author: Arnaud Joly, Joel Nothman, Hamzeh Alsalhi
 #
 # License: BSD 3 clause
@@ -172,9 +171,8 @@ def check_classification_targets(y):
         raise ValueError("Unknown label type: %r" % y_type)
 
 
-
 def type_of_target(y):
-    """Determine the type of data indicated by target ``y``
+    """Determine the type of data indicated by the target.
 
     Note that this type is the most specific type that can be inferred.
     For example:

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -592,17 +592,17 @@ def has_fit_parameter(estimator, parameter):
 
     Parameters
     ----------
-    estimator : object,
-        A scikit-learn estimator to introspect.
+    estimator : object
+        An estimator to inspect.
 
-    parameter: str,
+    parameter: str
         The searched parameter.
 
     Returns
     -------
-    is_parameter: bool,
-        Whether the parameter was found to be a member variable of the
-        estimator.
+    is_parameter: bool
+        Whether the parameter was found to be a a named parameter of the
+        estimator's fit method.
 
     Examples
     --------

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -43,12 +43,16 @@ def _assert_all_finite(X):
 def assert_all_finite(X):
     """Throw a ValueError if X contains NaN or infinity.
 
-    Input MUST be an np.ndarray instance or a scipy.sparse matrix."""
+    Parameters
+    ----------
+    X : np.ndarray, scipy.sparse
+        ``X`` MUST be an np.ndarray instance or a scipy.sparse matrix.
+    """
     _assert_all_finite(X.data if sp.issparse(X) else X)
 
 
 def as_float_array(X, copy=True, force_all_finite=True):
-    """Converts an array-like to an array of floats
+    """Converts an array-like to an array of floats.
 
     The new dtype will be np.float32 or np.float64, depending on the original
     type. The function can create a copy or modify the argument depending
@@ -585,6 +589,20 @@ def check_random_state(seed):
 
 def has_fit_parameter(estimator, parameter):
     """Checks whether the estimator's fit method supports the given parameter.
+
+    Parameters
+    ----------
+    estimator : object,
+        A scikit-learn estimator to introspect.
+
+    parameter: str,
+        The searched parameter.
+
+    Returns
+    -------
+    is_parameter: bool,
+        Whether the parameter was found to be a member variable of the
+        estimator.
 
     Examples
     --------


### PR DESCRIPTION
I added two functions in the user guide and enable the hyperlinks for the validation tools section.

Regarding the other sections (Efficient linear ...), a lot of functions do not have any hyperlink because they are not added in `doc/modules/classes.rst`. Shall I solve this by adding them at the expense to have a longer API section. If yes, I would think that we would need to organize the `utils` section into subsection similarly to the user guide. If not, I think this PR is enough.

WDYF?